### PR TITLE
fix error

### DIFF
--- a/lib/fluent/plugin/parser_msgpack.rb
+++ b/lib/fluent/plugin/parser_msgpack.rb
@@ -1,10 +1,13 @@
+require 'fluent/parser'
+
 module Fluent
   class TextParser
     class MsgPackParser < Parser
       Plugin.register_parser("msgpack", self)
 
       def parse(text)
-        yield MessagePack.unpack(text)
+        yield Fluent::EventTime.now, MessagePack.unpack(text)
+        # yield nil, MessagePack.unpack(text)
       end
     end
   end


### PR DESCRIPTION
1. require

 for '/lib/ruby/gems/2.4.0/gems/fluent-plugin-msgpack-parser-0.1.0/lib/fluent/plugin/parser_msgpack.rb:3:in `<class:TextParser>': uninitialized constant Fluent::TextParser::Parser (NameError)'

2. parse() yield

for '2020-07-03 17:36:36 +0900 [warn]: #0 pattern not matched message="\x82\..."'